### PR TITLE
Fixed acceptance of missing USB Identifier on linux (USB identifier is not needed anyway)

### DIFF
--- a/module/goxlrutilityapi/models/status.py
+++ b/module/goxlrutilityapi/models/status.py
@@ -35,7 +35,7 @@ class UsbDevice(DefaultBaseModel):
     version: list[int]
     bus_number: int
     address: int
-    identifier: str
+    identifier: str | None
 
 
 class Hardware(DefaultBaseModel):


### PR DESCRIPTION
# Proposed Changes

This PR fixes an issue where GoXLR devices cannot be added using the homeassistant integration when GoXLR Utility is running on a linux host. 
In that case, the USB Device Identifier is not properly reported (for whatever reason) which causes a validation error in the message handler.

This PR simply allows the identifier to be None, as it is not needed anywhere anyway.

The fix has been applied on version 1.2.3 of the codebase as the current master branch could not be successfully tested (should be easy to port though).


## Related Issues

https://github.com/timmo001/homeassistant-integration-goxlr-utility/issues/71
https://github.com/timmo001/homeassistant-integration-goxlr-utility/discussions/74


## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).
- [ ] Rebase on master when master is ready to test.

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
